### PR TITLE
Output to a bash script

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,15 @@ struct VariablesCommand {
     /// Ignore server certificate errors from a registry
     #[clap(short = 'k', long = "insecure", num_args = 0)]
     insecure: bool,
+
+    /// How to output the variables. The available options are:
+    /// 
+    /// * bash - a bash script which can be saved, edited, and used to export values
+    /// * table - a human-readable tabular display format
+    /// 
+    /// The default is table.
+    #[clap(short = 'o', long = "output", default_value = "table")]
+    output: OutputFormat,
 }
 
 impl VariablesCommand {
@@ -29,36 +38,16 @@ impl VariablesCommand {
             AppSource::Registry(reference) => variables_from_registry_app(&reference, self.insecure).await?,
         };
 
-        let mut table = comfy_table::Table::new();
-        table.set_header(comfy_table::Row::from(vec!["Name", "Required?", "Default value", "Secret?"]));
-        table.load_preset(comfy_table::presets::ASCII_BORDERS_ONLY_CONDENSED);
-
-        for variable in variables {
-            let default_value = variable.default_value.as_ref().map(|v| v.as_str()).unwrap_or_default();
-
-            let required = if variable.required {
-                "Required"
-            } else {
-                "Optional"
-            };
-
-            let secret = if variable.secret {
-                "Secret"
-            } else {
-                ""
-            };
-
-            table.add_row(vec![
-                variable.name.as_str(),
-                required,
-                default_value,
-                secret,
-            ]);
-        }
-
-        println!("{table}");
+        println!("{}", self.format_variables(&variables));
 
         Ok(())
+    }
+
+    fn format_variables(&self, variables: &[VariableInfo]) -> Box<dyn std::fmt::Display> {
+        match self.output {
+            OutputFormat::Table => Box::new(format_table(variables)),
+            OutputFormat::Bash => Box::new(format_bash(variables)),
+        }
     }
 }
 
@@ -92,6 +81,54 @@ async fn variables_from_registry_app(reference: &str, insecure: bool) -> anyhow:
     Ok(variables)
 }
 
+fn format_table(variables: &[VariableInfo]) -> impl std::fmt::Display {
+    let mut table = comfy_table::Table::new();
+    table.set_header(comfy_table::Row::from(vec!["Name", "Required?", "Default value", "Secret?"]));
+    table.load_preset(comfy_table::presets::ASCII_BORDERS_ONLY_CONDENSED);
+
+    for variable in variables {
+        let default_value = variable.default_value.as_ref().map(|v| v.as_str()).unwrap_or_default();
+
+        let required = if variable.required {
+            "Required"
+        } else {
+            "Optional"
+        };
+
+        let secret = if variable.secret {
+            "Secret"
+        } else {
+            ""
+        };
+
+        table.add_row(vec![
+            variable.name.as_str(),
+            required,
+            default_value,
+            secret,
+        ]);
+    }
+
+    table
+}
+
+fn format_bash(variables: &[VariableInfo]) -> impl std::fmt::Display {
+    let mut lines = vec![
+        "# You may `source` this or reference it in your runtime-config.toml via the `dotenv_path` field".to_owned(),
+        "".to_owned(),
+    ];
+    lines.extend(variables.iter().map(format_one_bash));
+    lines.join("\n")
+}
+
+fn format_one_bash(variable: &VariableInfo) -> String {
+    let env_var_name = format!("SPIN_VARIABLE_{}", variable.name.to_ascii_uppercase());
+    match &variable.default_value {
+        Some(default_value) => format!("# export {env_var_name}=\"{default_value}\"  # optional"),
+        None => format!("export {env_var_name}=TO-DO  # required"),
+    }
+}
+
 struct VariableInfo {
     name: String,
     default_value: Option<String>,
@@ -110,4 +147,10 @@ fn infer_app_source(provided: &Option<String>) -> anyhow::Result<AppSource> {
         Some(provided) if spin_oci::is_probably_oci_reference(provided) => Ok(AppSource::Registry(provided.clone())),
         Some(provided) => Ok(AppSource::File(spin_common::paths::resolve_manifest_file_path(provided)?)),
     }
+}
+
+#[derive(Clone, Debug, clap::ValueEnum)]
+enum OutputFormat {
+    Table,
+    Bash,
 }


### PR DESCRIPTION
Fixes #2.

It seems like Spin also supports `.env` files through the runtime config; this should be compatible with that as well as `source`.
